### PR TITLE
feat: Update the github action configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * [Create new command: restqa example](./example) | [#76](https://github.com/restqa/restqa/pull/76)
 
+### Update
+* [Update the Github action configuration: Upload the test report as an artifact](https://docs.restqa.io/ci-cd/github-action) | [#85](https://github.com/restqa/restqa/pull/85)
+
 ## [0.0.25] - 2021-05-04
 
 ### Added

--- a/src/cli/initialize.js
+++ b/src/cli/initialize.js
@@ -147,6 +147,13 @@ initialize.generate = async function (options) {
                 with: {
                   path: 'tests/'
                 }
+              }, {
+                name: 'RestQA Report',
+                uses: 'actions/upload-artifact@v2',
+                with: {
+                  name: 'restqa-report',
+                  path: 'report'
+                }
               }]
             }
           }

--- a/src/cli/initialize.test.js
+++ b/src/cli/initialize.test.js
@@ -95,6 +95,13 @@ describe('#Cli - Initialize', () => {
               with: {
                 path: 'tests/'
               }
+            }, {
+              name: 'RestQA Report',
+              uses: 'actions/upload-artifact@v2',
+              with: {
+                name: 'restqa-report',
+                path: 'report'
+              }
             }]
           }
         }


### PR DESCRIPTION
Since the html report became a default output, we need to update the github action configuration in order to upload the test report as an artifact.