### PR TITLE
feat: update gitlab-ci pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [Create new command: restqa example](./example) | [#76](https://github.com/restqa/restqa/pull/76)
 
 ### Update
-* [Update the Github action configuration: Upload the test report as an artifact](https://docs.restqa.io/ci-cd/github-action) | [#85](https://github.com/restqa/restqa/pull/85)
+* [Update the Github Action configuration: Upload the test report as an artifact](https://docs.restqa.io/ci-cd/github-action) | [#85](https://github.com/restqa/restqa/pull/85)
+* [Update the Gitlab-CI configuration: Upload the test report as an artifact](https://docs.restqa.io/ci-cd/gitlab-ci) | [#86](https://github.com/restqa/restqa/pull/86)
 
 ## [0.0.25] - 2021-05-04
 

--- a/src/cli/initialize.js
+++ b/src/cli/initialize.js
@@ -178,7 +178,12 @@ initialize.generate = async function (options) {
             },
             script: [
               'restqa run .'
-            ]
+            ],
+            artifacts: {
+              paths: [
+                'report'
+              ]
+            }
           }
         }
         createYaml(path.resolve(folder, '.gitlab-ci.yml'), jsonContent)

--- a/src/cli/initialize.test.js
+++ b/src/cli/initialize.test.js
@@ -153,7 +153,12 @@ describe('#Cli - Initialize', () => {
           },
           script: [
             'restqa run .'
-          ]
+          ],
+          artifacts: {
+            paths: [
+              'report'
+            ]
+          }
         }
       }
       expect(result).toEqual(expectedContent)
@@ -604,7 +609,12 @@ Given I have an example`
           },
           script: [
             'restqa run .'
-          ]
+          ],
+          artifacts: {
+            paths: [
+              'report'
+            ]
+          }
         }
       }
       expect(resultCi).toEqual(expectedContentCi)


### PR DESCRIPTION
Since the html report became a default output, we need to update the gitlab-ci configuration in order to upload the test report as an artifact.