### PR TITLE
feat: update bitbucket pipeline 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Update
 * [Update the Github Action configuration: Upload the test report as an artifact](https://docs.restqa.io/ci-cd/github-action) | [#85](https://github.com/restqa/restqa/pull/85)
 * [Update the Gitlab-CI configuration: Upload the test report as an artifact](https://docs.restqa.io/ci-cd/gitlab-ci) | [#86](https://github.com/restqa/restqa/pull/86)
+* [Update the Bitbucket Pipeline configuration: Upload the test report as an artifact](https://docs.restqa.io/ci-cd/bitbucket-pipeline) | [#87](https://github.com/restqa/restqa/pull/87)
 
 ## [0.0.25] - 2021-05-04
 

--- a/src/cli/initialize.js
+++ b/src/cli/initialize.js
@@ -198,6 +198,9 @@ initialize.generate = async function (options) {
                 image: 'restqa/restqa',
                 script: [
                   'restqa run .'
+                ],
+                artifacts: [
+                  'report/**'
                 ]
               }
             }]

--- a/src/cli/initialize.test.js
+++ b/src/cli/initialize.test.js
@@ -204,6 +204,9 @@ describe('#Cli - Initialize', () => {
               image: 'restqa/restqa',
               script: [
                 'restqa run .'
+              ],
+              artifacts: [
+                'report/**'
               ]
             }
           }]


### PR DESCRIPTION
Since the html report became a default output, we need to update the bitbucket pipeline configuration in order to upload the test report as an artifact.
Close.  #84 