### PR TITLE
chore: defer tweet and discord in publish ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         tags: "latest,${{ github.event.release.tag_name }}"
   discord-notify:
+    needs: npm-publish
     runs-on: ubuntu-latest
     steps:
       - name: Discord notification
@@ -45,6 +46,7 @@ jobs:
              }]
         uses: Ilshidur/action-discord@master
   tweet:
+    needs: npm-publish
     name: posting_on_twitter
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Change description

During the release of `0.0.35`, I observed that tweet and discord messages are published before the release really ends.

<img width="1011" alt="Screenshot 2021-10-27 at 06 46 49" src="https://user-images.githubusercontent.com/22824417/139002321-9b1a901e-7856-4148-83a8-47bbea607d9c.png">

Regarding Github actions [documentation](https://docs.github.com/en/actions/learn-github-actions/managing-complex-workflows#creating-dependent-jobs), I added the property `needs` set to `npm-publish` for:
- `discord-notify`
- `tweet`

Let me know if it's a good way to do it...

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fix #1

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows project security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to issue tracker where applicable

