### PR TITLE
Test: only run the welcome test links from the CI

### DIFF
--- a/src/utils/welcome.test.js
+++ b/src/utils/welcome.test.js
@@ -73,6 +73,7 @@ describe("# utils - welcome", () => {
 });
 
 test("Detect broken link from the messages", async () => {
+  if (undefined === process.env.CI) return
   const ignoreList = [
     "https://linkedin.com/company/restqa",
     "https://restqa.io/pair"


### PR DESCRIPTION
## Change description

In order to speed up the test execution, let's just keep the Link check on the CI