### PR TITLE
fix: init miss fallback values when package json exists

### DIFF
--- a/src/cli/initialize.js
+++ b/src/cli/initialize.js
@@ -86,7 +86,30 @@ async function initialize(program) {
 
     answers = await inquirer.prompt(questions);
   }
+
+  addDefaultAnswers(pkg, answers);
+
   return initialize.generate(answers);
+}
+
+/**
+ * 
+ * Overwrite answers object with value from package json
+ * (as default/fallback values)
+ * 
+ * @param {object} packageJson 
+ * @param {object} answers 
+ */
+function addDefaultAnswers(packageJson, answers) {
+  if (packageJson) {
+    if (packageJson.name && !answers.name) {
+      answers.name = packageJson.name;
+    }
+
+    if (packageJson.description && !answers.description) {
+      answers.description = packageJson.description;
+    }
+  }
 }
 
 initialize.generate = async function (options) {

--- a/src/cli/initialize.js
+++ b/src/cli/initialize.js
@@ -18,12 +18,12 @@ async function initialize(program) {
     telemetry: true
   };
 
-  const pkg = getPackageJson();
+  const packageJson = getPackageJson();
 
   if (program.y !== true) {
     const questions = []
 
-    if (!pkg || (pkg && !pkg.name)) {
+    if (!packageJson || (packageJson && !packageJson.name)) {
       questions.push({
         type: "input",
         name: "name",
@@ -87,7 +87,7 @@ async function initialize(program) {
     answers = await inquirer.prompt(questions);
   }
 
-  addDefaultAnswers(pkg, answers);
+  addDefaultFromPackageJson(packageJson, answers);
 
   return initialize.generate(answers);
 }
@@ -100,7 +100,7 @@ async function initialize(program) {
  * @param {object} packageJson 
  * @param {object} answers 
  */
-function addDefaultAnswers(packageJson, answers) {
+function addDefaultFromPackageJson(packageJson, answers) {
   if (packageJson) {
     if (packageJson.name && !answers.name) {
       answers.name = packageJson.name;

--- a/src/cli/initialize.test.js
+++ b/src/cli/initialize.test.js
@@ -876,6 +876,36 @@ Given I have an example`;
       expect(mockPrompt.mock.calls[0][0].map((_) => _.message)).toEqual(
         expectedQuestions
       );
-    })
+    });
+
+    test("Initialize should call Initialize.generate with a name if package json exists", async () => {
+      // Mocks
+      const options = {
+        port: 9090,
+        folder: os.tmpdir(),
+        telemetry: false
+      };
+      const mockPrompt = jest.fn().mockResolvedValue(options);
+
+      jest.mock("inquirer", () => {
+        return {
+          Separator: jest.fn(),
+          prompt: mockPrompt
+        };
+      });
+      const Initialize = require("./initialize");
+      Initialize.generate = jest.fn();
+      
+      // Given, When
+      await Initialize({y: false});
+
+      // Then
+      expect(Initialize.generate).toHaveBeenCalledWith(expect.objectContaining({
+        port: options.port,
+        telemetry: options.telemetry,
+        name: "@restqa/restqa",
+        description: "An all in one test automation runner"
+      }));
+    });
   });
 });


### PR DESCRIPTION
## Change description

Overwrite answers object with default/fallback values from `package.json`

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows project security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to issue tracker where applicable

