### PR TITLE
feat: display microservice logs (debug mode)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "editor.formatOnSave": true
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
 }

--- a/bin/program.js
+++ b/bin/program.js
@@ -66,6 +66,7 @@ program
     "-x, --exec <command>",
     "Run a command before running tests (example: npm start)"
   )
+  .option("-s, --silent", "Disable log from --exec command")
   .description("Execute the RestQA test suite")
   .usage("-c ./.restqa.yml -e local -t @success customer.feature")
   .action(Cli("run"));

--- a/bin/tests/run.bats
+++ b/bin/tests/run.bats
@@ -120,6 +120,16 @@ load 'common.sh'
   run restqa run . -x 'npm start'
   assert_success
   assert_output --partial 'Server is running (command: npm start)'
+  assert_output --partial 'Silent mode enabled'
+  assert_output --partial '1 scenario (1 passed)'
+}
+
+@test "[RUN]> EXEC > Execute a basic http server in silent mode" {
+  cd ./bin/tests/test-servers/basic
+  run npm i
+  run restqa run . -x 'npm start' -s
+  assert_success
+  assert_output --partial 'Server is running (command: npm start)'
   assert_output --partial '1 scenario (1 passed)'
 }
 

--- a/bin/tests/run.bats
+++ b/bin/tests/run.bats
@@ -120,7 +120,7 @@ load 'common.sh'
   run restqa run . -x 'npm start'
   assert_success
   assert_output --partial 'Server is running (command: npm start)'
-  assert_output --partial 'Silent mode enabled'
+  assert_output --partial '[DEBUG]'
   assert_output --partial '1 scenario (1 passed)'
 }
 
@@ -130,6 +130,7 @@ load 'common.sh'
   run restqa run . -x 'npm start' -s
   assert_success
   assert_output --partial 'Server is running (command: npm start)'
+  assert_output --partial 'Silent mode enabled'
   assert_output --partial '1 scenario (1 passed)'
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@restqa/restqa",
-  "version": "0.0.36",
+  "version": "0.0.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@restqa/restqa",
-      "version": "0.0.36",
+      "version": "0.0.38",
       "license": "MIT",
       "dependencies": {
         "@cucumber/cucumber": "^7.3.0",

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -5,6 +5,15 @@ const cucumber = require("@cucumber/cucumber");
 const {program: cliProgram} = require("../../bin/program");
 const logger = require("../utils/logger");
 
+function setGlobals(config, env, command, silent) {
+  global.restqaOptions = {
+    config,
+    env,
+    command,
+    silent
+  };
+}
+
 module.exports = async function (opt, program = {}) {
   let {
     env,
@@ -13,7 +22,8 @@ module.exports = async function (opt, program = {}) {
     stream = process.stdout,
     args,
     exec: command,
-    skipInit = false
+    skipInit = false,
+    silent = false
   } = opt;
 
   args = args || program.args || ["."];
@@ -60,13 +70,9 @@ module.exports = async function (opt, program = {}) {
         new TypeError(`The configuration file "${config}" doesn't exist.`)
       );
     }
-  } 
+  }
 
-  global.restqaOptions = {
-    config,
-    env,
-    command
-  };
+  setGlobals(config, env, command, silent);
 
   // TODO : Add extra cucumber parameters from config file
   const customOptions = [

--- a/src/core/executor.js
+++ b/src/core/executor.js
@@ -62,11 +62,13 @@ module.exports = {
     return new Promise((resolve, reject) => {
       const checker = () => {
         const socket = net.createConnection({port});
+
         socket.on("ready", function (err) {
           if (err) reject(err);
           resolve();
           socket.destroy();
         });
+
         socket.on("error", function (err) {
           socket.destroy();
           timeout -= 200;
@@ -84,6 +86,8 @@ module.exports = {
           }
         });
       };
+
+      // Start execution
       checker();
     });
   }

--- a/src/core/executor.js
+++ b/src/core/executor.js
@@ -15,16 +15,24 @@ function debug(message) {
   logger.debug(`[DEBUG]: ${message}`);
 }
 
+const defaultOptions = {
+  silent: false
+};
+
 module.exports = {
   /**
    *
    * @param {string} command
    * @param {object} envs
    * @param {object} options execute command options
-   * @param {boolean} options.debug enable log from executed command
+   * @param {boolean} options.silent enable log from executed command
    */
-  execute: async function executeCommand(command, envs, options = {}) {
-    const isDebugModeEnabled = options.debug;
+  execute: async function executeCommand(
+    command,
+    envs = Object.create(null),
+    options = defaultOptions
+  ) {
+    const isSilent = options.silent;
 
     return new Promise((resolve, reject) => {
       if (typeof command === "string") {
@@ -52,15 +60,14 @@ module.exports = {
             initialized = true;
             logger.success(`Server is running (command: ${command})`);
 
-            if (isDebugModeEnabled) {
-              debug("debug mode enabled!");
-              debug(data.toString());
+            if (isSilent) {
+              logger.warning("Silent mode enabled");
             }
 
-            return resolve(server);
+            resolve(server);
           }
 
-          if (isDebugModeEnabled) {
+          if (!isSilent) {
             debug(data.toString());
           }
         });

--- a/src/core/executor.js
+++ b/src/core/executor.js
@@ -60,7 +60,7 @@ module.exports = {
             initialized = true;
             logger.success(`Server is running (command: ${command})`);
 
-            if (isSilent) {
+            if (!isSilent) {
               logger.warning("Silent mode enabled");
             }
 

--- a/src/core/executor.js
+++ b/src/core/executor.js
@@ -12,7 +12,7 @@ const {format} = require("util");
  * @param {string} message message to print
  */
 function debug(message) {
-  logger.debug(`[DEBUG]: ${message}`);
+  logger.info(`[DEBUG]: ${message}`);
 }
 
 const defaultOptions = {

--- a/src/core/executor.js
+++ b/src/core/executor.js
@@ -4,13 +4,28 @@ const net = require("net");
 const Locale = require("../locales")("service.run");
 const {format} = require("util");
 
+/**
+ *
+ * Will print a debug message
+ * with the decorator `[DEBUG]`
+ *
+ * @param {string} message message to print
+ */
+function debug(message) {
+  logger.debug(`[DEBUG]: ${message}`);
+}
+
 module.exports = {
   /**
    *
    * @param {string} command
    * @param {object} envs
+   * @param {object} options execute command options
+   * @param {boolean} options.debug enable log from executed command
    */
-  execute: async function executeCommand(command, envs) {
+  execute: async function executeCommand(command, envs, options = {}) {
+    const isDebugModeEnabled = options.debug;
+
     return new Promise((resolve, reject) => {
       if (typeof command === "string") {
         let initialized = false;
@@ -31,12 +46,22 @@ module.exports = {
         });
 
         // resolve when process is spawn successfully
-        server.stdout.on("data", () => {
+        // and log data in debug mode
+        server.stdout.on("data", (data) => {
           if (!initialized) {
             initialized = true;
             logger.success(`Server is running (command: ${command})`);
 
-            resolve(server);
+            if (isDebugModeEnabled) {
+              debug("debug mode enabled!");
+              debug(data.toString());
+            }
+
+            return resolve(server);
+          }
+
+          if (isDebugModeEnabled) {
+            debug(data.toString());
           }
         });
 

--- a/src/core/executor.js
+++ b/src/core/executor.js
@@ -60,7 +60,7 @@ module.exports = {
             initialized = true;
             logger.success(`Server is running (command: ${command})`);
 
-            if (!isSilent) {
+            if (isSilent) {
               logger.warning("Silent mode enabled");
             }
 

--- a/src/core/executor.test.js
+++ b/src/core/executor.test.js
@@ -8,13 +8,17 @@ describe("# utils - executor", () => {
     .spyOn(require("../utils/logger"), "success")
     .mockImplementation(jest.fn());
 
-  const loggerDebugSpy = jest
-    .spyOn(require("../utils/logger"), "debug")
+  const loggerInfoSpy = jest
+    .spyOn(require("../utils/logger"), "info")
     .mockImplementation(jest.fn());
 
   const loggerWarningSpy = jest
     .spyOn(require("../utils/logger"), "warning")
     .mockImplementation(jest.fn());
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
   test("given an valid command when we execute it then process.stdout.write should have been called", async () => {
     // Given
@@ -89,7 +93,7 @@ describe("# utils - executor", () => {
 
     // Then
     const firstCharactersFromLsCommand = "total";
-    expect(loggerDebugSpy).toHaveBeenCalledWith(
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
       expect.stringContaining(`[DEBUG]: ${firstCharactersFromLsCommand}`)
     );
   });

--- a/src/core/executor.test.js
+++ b/src/core/executor.test.js
@@ -12,6 +12,10 @@ describe("# utils - executor", () => {
     .spyOn(require("../utils/logger"), "debug")
     .mockImplementation(jest.fn());
 
+  const loggerWarningSpy = jest
+    .spyOn(require("../utils/logger"), "warning")
+    .mockImplementation(jest.fn());
+
   test("given an valid command when we execute it then process.stdout.write should have been called", async () => {
     // Given
     const validCommand = "ls -l";
@@ -74,21 +78,33 @@ describe("# utils - executor", () => {
     }
   });
 
-  test("given a debug option passed it should log each stdout data", async () => {
+  test("given a silent set to false it should log each stdout data", async () => {
     // Given
     const validCommand = "ls -l";
     const envs = {};
-    const options = {debug: true};
+    const options = {silent: false};
 
     // When
     await execute(validCommand, envs, options);
 
     // Then
     expect(loggerDebugSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[DEBUG]: debug mode enabled!")
-    );
-    expect(loggerDebugSpy).toHaveBeenCalledWith(
       expect.stringContaining("[DEBUG]: total")
+    );
+  });
+
+  test("given a silent set to true it should display a warning message", async () => {
+    // Given
+    const validCommand = "ls -l";
+    const envs = {};
+    const options = {silent: true};
+
+    // When
+    await execute(validCommand, envs, options);
+
+    // Then
+    expect(loggerWarningSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Silent mode enabled")
     );
   });
 });

--- a/src/core/executor.test.js
+++ b/src/core/executor.test.js
@@ -88,8 +88,9 @@ describe("# utils - executor", () => {
     await execute(validCommand, envs, options);
 
     // Then
+    const firstCharactersFromLsCommand = "total";
     expect(loggerDebugSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[DEBUG]: total")
+      expect.stringContaining(`[DEBUG]: ${firstCharactersFromLsCommand}`)
     );
   });
 

--- a/src/core/executor.test.js
+++ b/src/core/executor.test.js
@@ -8,6 +8,10 @@ describe("# utils - executor", () => {
     .spyOn(require("../utils/logger"), "success")
     .mockImplementation(jest.fn());
 
+  const loggerDebugSpy = jest
+    .spyOn(require("../utils/logger"), "debug")
+    .mockImplementation(jest.fn());
+
   test("given an valid command when we execute it then process.stdout.write should have been called", async () => {
     // Given
     const validCommand = "ls -l";
@@ -68,5 +72,23 @@ describe("# utils - executor", () => {
         new Error(`Error during running command ${commandShouldFail}`)
       );
     }
+  });
+
+  test("given a debug option passed it should log each stdout data", async () => {
+    // Given
+    const validCommand = "ls -l";
+    const envs = {};
+    const options = {debug: true};
+
+    // When
+    await execute(validCommand, envs, options);
+
+    // Then
+    expect(loggerDebugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[DEBUG]: debug mode enabled!")
+    );
+    expect(loggerDebugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[DEBUG]: total")
+    );
   });
 });

--- a/src/core/plugin.js
+++ b/src/core/plugin.js
@@ -3,7 +3,7 @@ const treekill = require("treekill");
 const {execute, checkServer} = require("../core/executor");
 const Locale = require("../locales")("service.run");
 
-module.exports = function ({command, config}, processor = {}) {
+module.exports = function ({command, config, silent = false}, processor = {}) {
   if (!processor.BeforeAll || !processor.AfterAll) {
     throw new Error(
       "Please provide a processor containing the methods:  BeforeAll, AfterAll"
@@ -11,7 +11,7 @@ module.exports = function ({command, config}, processor = {}) {
   }
 
   processor.Before(async function (scenario) {
-    // In order to fetch the dynamic data from extenral sources.
+    // In order to fetch the dynamic data from external sources.
     // Let's parse the scenario to get all the placeholder
     await this.data.parse(scenario);
   });
@@ -25,11 +25,11 @@ module.exports = function ({command, config}, processor = {}) {
     let server;
     processor.BeforeAll(async function () {
       if (typeof command === "string") {
-        const restqapi = getPluginConfig("@restqa/restqapi", config);
-        if (!restqapi) {
+        const pluginConfig = getPluginConfig("@restqa/restqapi", config);
+        if (!pluginConfig) {
           throw new Error(Locale.get("error_missing_restqapi"));
         }
-        const {url} = restqapi;
+        const {url} = pluginConfig;
         if (!url) {
           throw new Error(Locale.get("error_missing_url"));
         }
@@ -40,7 +40,7 @@ module.exports = function ({command, config}, processor = {}) {
 
         const {mock} = this.restqa || {};
         const envs = (mock || {}).http;
-        server = await execute(command, envs);
+        server = await execute(command, envs, {silent});
         await checkServer(port);
       }
     });

--- a/src/setup.js
+++ b/src/setup.js
@@ -1,16 +1,18 @@
 const Cucumber = require("@cucumber/cucumber");
 const Bootstrap = require("./core/bootstrap");
 
-if (global.restqaOptions.env) {
-  process.env.RESTQA_ENV =
-    global.restqaOptions.env && String(global.restqaOptions.env).toUpperCase();
+const globals = global.restqaOptions;
+
+if (globals.env) {
+  process.env.RESTQA_ENV = globals.env && String(globals.env).toUpperCase();
 }
-process.env.RESTQA_CONFIG = global.restqaOptions.config;
+process.env.RESTQA_CONFIG = globals.config;
 
 const options = {
   env: process.env.RESTQA_ENV,
   configFile: process.env.RESTQA_CONFIG,
-  command: global.restqaOptions.command
+  command: globals.command,
+  silent: globals.silent
 };
 
 Bootstrap(Cucumber, options);


### PR DESCRIPTION
## Change description

This pull request is an attempt to resolve issue #164 

In the context of `run` command, RQA allows users to pass a command to spin up the server before running tests.

The command is spawned but the stdout was ignored at the moment. 

The goal of this initiative is to allow users to get it back (on demand)

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

Fix #164 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows project security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to issue tracker where applicable

