### PR TITLE
feat: During the first installation we should have a standard scenario

### DIFF
--- a/cli/src/cli/generate.js
+++ b/cli/src/cli/generate.js
@@ -159,7 +159,7 @@ module.exports = async function (pOptions, program) {
       options.headers["user-agent"] = opt.userAgent;
     }
 
-    const result = await Generator(options);
+    const result = await Generator(options, false);
 
     if (opt.output) {
       const filename = path.resolve(process.cwd(), opt.output);

--- a/examples/nodejs/tests/local/get.feature
+++ b/examples/nodejs/tests/local/get.feature
@@ -2,7 +2,7 @@ Feature: Welcome to the RestQA community
 
 @performance
 Scenario: Initial scenario
-Given a request hosted on "http://localhost:8000"
+Given a request
 When GET "/"
 Then status = 200
   And the body:

--- a/plugins/rest-api/src/index.test.js
+++ b/plugins/rest-api/src/index.test.js
@@ -31,6 +31,86 @@ describe("# rest-api.Generator", () => {
     );
   });
 
+  test("Use method get if it's not specified (not include host)", async () => {
+    const got = require("got");
+    got.mockResolvedValue({
+      restqa: {
+        statusCode: 200,
+        req: {
+          path: "/"
+        },
+        timings: {
+          phases: {
+            total: 1000
+          }
+        },
+        headers: {
+          "content-type": "application/json"
+        },
+        body: {
+          foo: "bar",
+          number: 12,
+          booTrue: true,
+          booFalse: false,
+          null: null
+        }
+      }
+    });
+    jest.mock("got");
+    const RestAPI = require("./index");
+    const query = {
+      url: "http://www.example.com?q=restqa",
+      body: {
+        hello: "world",
+        bonjour: "le monde"
+      }
+    };
+    const result = await RestAPI.Generator(query, false);
+    const expectedResult = `
+Given a request
+  And the query strings:
+    | q | restqa |
+  And the payload:
+  """
+{
+  "hello": "world",
+  "bonjour": "le monde"
+}
+  """
+When GET "/"
+Then status = 200
+  And the body:
+  """
+{
+  "foo": "bar",
+  "number": 12,
+  "booTrue": true,
+  "booFalse": false,
+  "null": null
+}
+  """
+`;
+    expect(result).toEqual(expectedResult.trim());
+
+    const expectedOptions = {
+      pathname: "/",
+      method: "GET",
+      protocol: "http:",
+      hostname: "www.example.com",
+      searchParams: {
+        q: "restqa"
+      },
+      json: {
+        hello: "world",
+        bonjour: "le monde"
+      }
+    };
+    expect(got.mock.calls).toHaveLength(1);
+    expect(got.mock.calls[0][0]).toEqual(
+      expect.objectContaining(expectedOptions)
+    );
+  });
+
   test("Use method get if it's not specified", async () => {
     const got = require("got");
     got.mockResolvedValue({

--- a/plugins/rest-api/src/rest-api/lib/generator.js
+++ b/plugins/rest-api/src/rest-api/lib/generator.js
@@ -3,7 +3,7 @@ const API = require("./api");
 const Response = require("./api/response");
 const Steps = require("../steps");
 
-module.exports = async function (transaction) {
+module.exports = async function (transaction, includeHost) {
   let api;
   if (transaction && transaction.response) {
     api = getFromFull(transaction);
@@ -37,16 +37,16 @@ module.exports = async function (transaction) {
     tags = tags.split(",").map((_) => _.trim());
     if (!tags.includes("generator")) return;
 
-    if (api.type === "PARTIAL") {
+    if (api.type === "FULL" || includeHost === false) {
+      if (tags.includes("gateway")) {
+        mapping.request.host = definition;
+      }
+    } else if (api.type === "PARTIAL") {
       if (tags.includes("host")) {
         mapping.request.host = definition.replace(
           "{string}",
           `"${api.URL.origin}"`
         );
-      }
-    } else if (api.type === "FULL") {
-      if (tags.includes("gateway")) {
-        mapping.request.host = definition;
       }
     }
 


### PR DESCRIPTION
## Change description

Let's have a standard scenario generation during the installation of RestQA

## Type of change
- [ ] Bug fix (fixes an issue)
- [X] New feature (adds functionality)

## Related issues

Fix #236 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows project security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to issue tracker where applicable

