### PR TITLE
feat: use raw command instead of npm script ones

### DIFF
--- a/packages/cli/src/core/plugin.js
+++ b/packages/cli/src/core/plugin.js
@@ -6,6 +6,22 @@ const HttpMock = require("./http-mock");
 const Collection = require("./collection");
 const path = require("path");
 const Coverage = require("./coverage");
+const {getPackageJson} = require("../utils/fs");
+
+function formatCommand(command) {
+  if (typeof command !== "string") {
+    throw new Error(`Plugin: command should be a string but got: ${command}`);
+  }
+
+  const isNpmCommand = command.startsWith("npm run");
+  if (!isNpmCommand) return command;
+  else {
+    const scriptName = command.slice(8);
+    const pkgJson = getPackageJson();
+    return pkgJson.scripts[scriptName];
+  }
+}
+
 
 module.exports = function ({env, report, config}, processor = {}) {
   global.result = {};
@@ -32,9 +48,11 @@ module.exports = function ({env, report, config}, processor = {}) {
     processor.BeforeAll(async function () {
       this.restqa = this.restqa || {};
       const {envs} = this.restqa.mock || {};
+      const commandFromConfig = config.getLocalTest().getCommand();
+      const command = formatCommand(commandFromConfig);
       const options = {
         port: config.getLocalTest().getPort(),
-        command: config.getLocalTest().getCommand(),
+        command,
         envs
       };
 


### PR DESCRIPTION
## Change description

- use raw command in examples repos
- update initializer to use command instead of script aliases

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Ref #252 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows project security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to issue tracker where applicable

