### PR TITLE
fix: add a loading message while the swagger ui is loading - report ui

### DIFF
--- a/packages/report-ui/src/components/restqa/specification/Specification.vue
+++ b/packages/report-ui/src/components/restqa/specification/Specification.vue
@@ -5,6 +5,9 @@
     :closable="false"
     v-if="hasError"
   />
+  <div class="spacer" v-if="loading">
+    Wait a second, your api specification is baking!
+  </div>
   <div class="swagger" id="swagger" v-loading="loading"></div>
 </template>
 
@@ -56,3 +59,13 @@ export default {
   },
 };
 </script>
+<style scoped>
+.spacer {
+  padding-top: 100px;
+  height: 60px;
+  text-align: center;
+  color: #8c40ff;
+}
+div.swagger div {
+}
+</style>


### PR DESCRIPTION
## Change description

Since the swagger ui is the lazy loaded, we just add a message to mention to the user to wait a bit :)

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fix #285

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows project security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to issue tracker where applicable

