### PR TITLE
fix: Allow to be pass query string in the same step of the path

### DIFF
--- a/packages/plugin-rest-api/src/rest-api/steps/2-when/functions.js
+++ b/packages/plugin-rest-api/src/rest-api/steps/2-when/functions.js
@@ -1,11 +1,17 @@
+const {URL} = require("url");
 const When = {};
 
 When.callApi = function (method) {
-  return async function (path) {
+  return async function (pathname) {
     this.api = this.api || this.createApi();
     try {
-      path = this.data.get(path);
-      this.api.request.setPath(encodeURI(path));
+      pathname = this.data.get(pathname);
+      const url = new URL(pathname, "http://fake.com");
+      url.searchParams.forEach((value, key) => {
+        this.api.request.setQueryString(key, value);
+      });
+
+      this.api.request.setPath(encodeURI(url.pathname));
 
       method = method.toLowerCase();
       const allowed = [

--- a/packages/plugin-rest-api/src/rest-api/steps/2-when/functions.test.js
+++ b/packages/plugin-rest-api/src/rest-api/steps/2-when/functions.test.js
@@ -54,5 +54,81 @@ describe("#StepDefinition - given - functions", () => {
         '"PUTT" is not a valid http method. Accepted : https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods'
       );
     });
+
+    test("callApi GET with 1 query parameter", async () => {
+      const $this = {
+        data: {
+          get: (_) => _
+        },
+        api: {
+          request: {
+            setMethod: jest.fn(),
+            setPath: jest.fn(),
+            setQueryString: jest.fn()
+          },
+          run: jest.fn().mockResolvedValue(true),
+          getCurl: () => "curl http://localhost/"
+        },
+        attach: jest.fn()
+      };
+
+      const fn = When.callApi("GET");
+
+      await fn.call($this, "/users?firstname=john");
+
+      expect($this.api.run.mock.calls).toHaveLength(1);
+      expect($this.api.run.mock.calls[0][0]).toBeUndefined();
+      expect($this.attach.mock.calls).toHaveLength(1);
+      expect($this.attach.mock.calls[0][0]).toEqual("curl http://localhost/");
+      expect($this.api.request.setMethod.mock.calls).toHaveLength(1);
+      expect($this.api.request.setMethod.mock.calls[0][0]).toEqual("get");
+      expect($this.api.request.setPath.mock.calls).toHaveLength(1);
+      expect($this.api.request.setPath.mock.calls[0][0]).toEqual("/users");
+      expect($this.api.request.setQueryString.mock.calls).toHaveLength(1);
+      expect($this.api.request.setQueryString.mock.calls[0][0]).toEqual(
+        "firstname"
+      );
+      expect($this.api.request.setQueryString.mock.calls[0][1]).toEqual("john");
+    });
+
+    test("callApi GET with multiple query parameters", async () => {
+      const $this = {
+        data: {
+          get: (_) => _
+        },
+        api: {
+          request: {
+            setMethod: jest.fn(),
+            setPath: jest.fn(),
+            setQueryString: jest.fn()
+          },
+          run: jest.fn().mockResolvedValue(true),
+          getCurl: () => "curl http://localhost/"
+        },
+        attach: jest.fn()
+      };
+
+      const fn = When.callApi("GET");
+
+      await fn.call($this, "/users?firstname=john&lastname=doe");
+
+      expect($this.api.run.mock.calls).toHaveLength(1);
+      expect($this.api.run.mock.calls[0][0]).toBeUndefined();
+      expect($this.attach.mock.calls).toHaveLength(1);
+      expect($this.attach.mock.calls[0][0]).toEqual("curl http://localhost/");
+      expect($this.api.request.setMethod.mock.calls).toHaveLength(1);
+      expect($this.api.request.setMethod.mock.calls[0][0]).toEqual("get");
+      expect($this.api.request.setPath.mock.calls).toHaveLength(1);
+      expect($this.api.request.setPath.mock.calls[0][0]).toEqual("/users");
+      expect($this.api.request.setQueryString.mock.calls).toHaveLength(2);
+      expect($this.api.request.setQueryString.mock.calls[0][0]).toEqual(
+        "firstname"
+      );
+      expect($this.api.request.setQueryString.mock.calls[0][1]).toEqual("john");
+      expect($this.api.request.setQueryString.mock.calls[1][0]).toEqual(
+        "lastname"
+      );
+      expect($this.api.request.setQueryString.mock.calls[1][1]).toEqual("doe");
+    });
   });
 });


### PR DESCRIPTION
## Change description

>  Let's allow to pass query parameters in the path as well

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fix #331 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows project security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to issue tracker where applicable

