### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Publish Docker
-      uses: elgohr/Publish-Docker-Github-Action@2.12
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         RESTQA_VERSION: ${{ github.event.release.tag_name }}
       with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore