### PR TITLE
Feat: inject the NODE_ENV variable by default as "test"

### DIFF
--- a/packages/core-microservice/src/index.js
+++ b/packages/core-microservice/src/index.js
@@ -68,6 +68,7 @@ class Microservice {
     const envs = this.envs || {};
     envs.PORT = this.port;
     envs.NODE_V8_COVERAGE = this.coveragePath;
+    envs.NODE_ENV = process.env.NODE_ENV || "test";
     return new Promise((resolve, reject) => {
       if (typeof command === "string") {
         let initialized = false;


### PR DESCRIPTION
## Change description

While the microservice is starting lets inject the environment variable that will define the NODE_ENV=test

## Type of change
- [ ] Bug fix (fixes an issue)
- [X] New feature (adds functionality)

## Related issues

Fix #353 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows project security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to issue tracker where applicable

